### PR TITLE
Fix webhook response and switch condition

### DIFF
--- a/My workflow.json
+++ b/My workflow.json
@@ -523,7 +523,7 @@
     {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={ \"etiquetas\": {{ $json.etiquetas || [] }} }\n\n\n",
+        "responseBody": "={{ { \"etiquetas\": $json.etiquetas || [] } }}",
         "options": {}
       },
       "type": "n8n-nodes-base.respondToWebhook",
@@ -635,7 +635,7 @@
                 "conditions": [
                   {
                     "leftValue": "={{ $json.body.funcion }}",
-                    "rightValue": "=pedir_etiquetas",
+                    "rightValue": "pedir_etiquetas",
                     "operator": {
                       "type": "string",
                       "operation": "equals"


### PR DESCRIPTION
## Summary
- fix response body in Respond to Webhook node
- update the first switch rule in Funcion to remove equals sign

## Testing
- `jq '.' 'My workflow.json' > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_687281b4aa60832b8a5727f1865bc29a